### PR TITLE
Remove linebreak style rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -116,7 +116,7 @@
     "indent": [ 2, 2 ],
     "key-spacing": [ 0, { "beforeColon": true, "afterColon": true, "align": "colon" } ],
     "keyword-spacing": [2, {"before": true, "after": true}],
-    "linebreak-style": [ 2, "unix" ],
+    "linebreak-style": 0,
     "lines-around-comment": [ 2, { "beforeBlockComment": true, "beforeLineComment": false } ],
     "max-nested-callbacks": [ 2, 3 ],
     "new-cap": 2,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codestyle",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "repository": "git@github.com:LeoGears/codestyle.git",
   "description": "ESLint configuration used at Gears of Leo",
   "scripts": {


### PR DESCRIPTION
Linebreaks are automatically fixed by git when you commit/push, so this rule only causes people using Windows to get errors on every single line