### PR TITLE
Disable strict rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -96,7 +96,7 @@
     "yoda": 2,
 
 
-    "strict": [ 2, "global" ],
+    "strict": 0,
 
 
     "no-catch-shadow": 2,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codestyle",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "repository": "git@github.com:LeoGears/codestyle.git",
   "description": "ESLint configuration used at Gears of Leo",
   "scripts": {


### PR DESCRIPTION
Been struggling with getting this rule to behave, input would be appreciated

So far every permutation I've tried of it, this code fails the rule:

```javascript
'use strict';

class Couchbase {
    constructor(config) {
        this.url = config.url;
    }
}
```

Naturally, removing `'use strict';` here throws an error in Node since classes can't be used outside of strict mode.