### PR TITLE
Disable spread rule and change dot location

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -43,7 +43,7 @@
     "consistent-return": 1,
     "curly": 2,
     "default-case": 2,
-    "dot-location": 2,
+    "dot-location": [2, "property"],
     "dot-notation": 2,
     "eqeqeq": 2,
     "guard-for-in": 2,
@@ -179,7 +179,7 @@
     "prefer-arrow-callback": 1,
     "prefer-const": 2,
     "prefer-reflect": 0,
-    "prefer-spread": 2,
+    "prefer-spread": 0,
     "prefer-template": 0,
     "require-yield": 2
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codestyle",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "repository": "git@github.com:LeoGears/codestyle.git",
   "description": "ESLint configuration used at Gears of Leo",
   "scripts": {


### PR DESCRIPTION
Case:
```
router.route('/sports').
       all(auth.route).
       post(sports);
```
I propose the dot location be *after* the newline, rather than before as we have now. That makes it act more as a pipe operator which helps with readability.

Google code style:
>When a line is broken at a non-assignment operator the break comes before the symbol. 

AirBnB Javascript code style:
>Use indentation when making long method chains (more than 2 method chains). Use a leading dot, which emphasizes that the line is a method call, not a new statement

This PR also disables the spread rule which isn't compatible with our version of node.