### PR TITLE
Enforce multi spaces on keys, allow multi space on variable assignment 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -66,7 +66,17 @@
     "no-lone-blocks": 2,
     "no-loop-func": 2,
     "no-magic-numbers": 0,
-    "no-multi-spaces": 2,
+    "no-multi-spaces":  [
+      "error",
+      {
+        "exceptions":
+        {
+          "Property": true,
+          "VariableDeclarator": true,
+          "ImportDeclaration": true
+        }
+      }
+    ],
     "no-multi-str": 2,
     "no-native-reassign": 2,
     "no-new-func": 2,

--- a/.eslintrc
+++ b/.eslintrc
@@ -124,7 +124,20 @@
     "func-style": [ 2, "declaration", { "allowArrowFunctions": true } ],
     "id-length": 0,
     "indent": [2, 2, { "SwitchCase": 1 }],
-    "key-spacing": [ 0, { "beforeColon": true, "afterColon": true, "align": "colon" } ],
+    "key-spacing"     : [
+      "error",
+      {
+        "singleLine" : {
+          "beforeColon" : false,
+          "afterColon"  : true
+        },
+        "multiLine"  : {
+          "beforeColon" : true,
+          "afterColon"  : true,
+          "align"       : "colon"
+        }
+      }
+    ],
     "keyword-spacing": [2, {"before": true, "after": true}],
     "linebreak-style": 0,
     "lines-around-comment": [ 2, { "beforeBlockComment": true, "beforeLineComment": false } ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codestyle",
-  "version": "13.0.0",
+  "version": "12.0.0",
   "repository": "git@github.com:LeoGears/codestyle.git",
   "description": "ESLint configuration used at Gears of Leo",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codestyle",
-  "version": "12.0.0",
+  "version": "13.0.0",
   "repository": "git@github.com:LeoGears/codestyle.git",
   "description": "ESLint configuration used at Gears of Leo",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codestyle",
-  "version": "11.0.1",
+  "version": "12.0.0",
   "repository": "git@github.com:LeoGears/codestyle.git",
   "description": "ESLint configuration used at Gears of Leo",
   "scripts": {


### PR DESCRIPTION
This change allows you to do nice things 



**From this**
```javascript
const async = require('async');
const _ = require('lodash');
const constants = require('@longgroupname/thing');

const opns = {
  Property: true,
  VariableDeclarator: true,
  ImportDeclaration: true
}
```

**To this**
```javascript
const async     = require('async');
const _         = require('lodash');
const constants = require('@longgroupname/thing');

const opns = {
  Property           : true,
  VariableDeclarator : true,
  ImportDeclaration  : true
}
```
